### PR TITLE
fix: Updated the operator space to a dictionary instead of a list.

### DIFF
--- a/src/autora/__init__.py
+++ b/src/autora/__init__.py
@@ -29,7 +29,7 @@ class ExampleRegressor(BaseEstimator):
 
     def __init__(self, degree: int = 3):
       # define the operator space
-      self.operator_space = ['+', '-', '*', '/', 'exp', 'ln', 'pow']
+      self.operator_space = {'+': 2, '-': 2, '*':2, '/':2, 'exp':1, 'ln':1, 'pow':2}
       #defined the variable space
       # cons: constant
       # eqn: is another equation, will cause a child fit process to run. 


### PR DESCRIPTION
# Description
Changed the operator space to a dictionary, with number of operands as the value.
if value more than 1, get the remaining variables using get:variables.

*If the issue is on Github, simply link to it using the '#' symbol; otherwise, provide a notion page link)*:
- resolves #1

# Type of change

- **fix**: A bug fix
